### PR TITLE
Adding multidomain certificates and more

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,4 +12,13 @@ letsencrypt_account_key: '{{ acme_tiny_data_directory }}/account.key'
 letsencrypt_user: 'letsencrypt'
 letsencrypt_group: 'letsencrypt'
 
-...
+..._n_weeks: 8
+
+letsencrypt_account_key: '{{ acme_tiny_data_directory }}/account.key'
+
+letsencrypt_user: 'letsencrypt'
+letsencrypt_group: 'letsencrypt'
+
+letsencrypt_keys_dir: '/etc/ssl/letsencrypt/private'
+letsencrypt_certs_dir: '/etc/ssl/letsencrypt/certs'
+letsencrypt_intermediate_cert: "{{ letsencrypt_certs_dir }}/lets-encrypt-x1-cross-signed.pem"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,5 @@
+
+- name: generate certs
+  shell: cd {{ acme_tiny_data_directory }} && ./renew-certs.py
+  become: yes
+  become_user: "{{ letsencrypt_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,4 +97,46 @@
     name: "letsencrypt certificate renewal"
     user: "{{ letsencrypt_user }}"
 
+...t
+
+- name: generate private keys
+  shell: "openssl genrsa 4096 > {{ item.keypath }}"
+  args:
+    creates: "{{ item.keypath }}"
+  with_items: letsencrypt_certs
+  tags: letsencrypt
+
+- name: generate csrs for singledomain keys
+  shell: "openssl req -new -sha256 -key '{{ item.keypath }}' -subj '/CN={{ item.host }}'
+    > {{ acme_tiny_data_directory }}/csrs/{{ item.name }}.csr"
+  args:
+    creates: "{{ acme_tiny_data_directory }}/csrs/{{ item.name }}.csr"
+  when: not {{ item.multiple|default(false) }}
+  with_items: letsencrypt_certs
+  tags: letsencrypt
+  # notify: generate certs
+
+- name: generate csrs for multidomain keys
+  raw: "openssl req -new -sha256 -key '{{ item.keypath }}' -subj '/' -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf '[SAN]\nsubjectAltName=DNS:{{ item.hosts|join(',DNS:') }}')) > {{ acme_tiny_data_directory }}/csrs/{{ item.name }}.csr"
+  args:
+    creates: "{{ acme_tiny_data_directory }}/csrs/{{ item.name }}.csr"
+  when: item.multiple|default(false)
+  with_items: letsencrypt_certs
+  tags: letsencrypt
+  # notify: generate certs
+
+#################################################
+# cron setup
+
+- name: install cronjob for key generation
+  cron:
+    job: "cd {{ acme_tiny_data_directory }} && ./renew-certs.py"
+    # run the job every week so we get a new certificate in time, even if it fails on the first attempt
+    special_time: weekly
+    cron_file: letsencrypt
+    state: present
+    name: "letsencrypt certificate renewal"
+    user: "{{ letsencrypt_user }}"
+  tags: letsencrypt
+
 ...

--- a/templates/renew-certs.py
+++ b/templates/renew-certs.py
@@ -41,3 +41,10 @@ for cert in certs:
         f = open(cert['certpath'], 'w')
         f.write(output)
         f.close()
+ open(cert['certpath'], 'w')
+        # add cert
+        f.write(output)
+        # add intermediate letsencrypt cert
+        with open('{{ letsencrypt_intermediate_cert }}', 'r') as intermediate_cert:
+            f.write(intermediate_cert.read())
+        f.close()


### PR DESCRIPTION
Hi,

I really liked your role and how it's simpler than original letsencrypt script.

I needed multidomain certificates and other features so:
- I added support for multidomain certs (trying to use current variable structure), ex:

```
  - name: "example.com"
    keypath: "{{ letsencrypt_keys_dir }}/example.com.key"
    certpath: "{{ letsencrypt_certs_dir }}/example.com.crt"
    multiple: true
    hosts:
      - example.com
      - www.example.com
  - name: "blog.example.com"
    keypath: "{{ letsencrypt_keys_dir }}/blog.example.com.key"
    certpath: "{{ letsencrypt_certs_dir }}/blog.example.com.crt"
    host: blog.example.com
```

this could probably be done better (without `multiple` variable - just checking for host/hosts variables but it was working fine and I didn't find time to fix this)
- certificates chaining for nginx (in renew-script)
- move cron to /etc/cron.d - this seems for me to be a better place than user cron,
- reorganise directories and permissions a little

Use it if you want :)
