### PR TITLE
 fix ownership for the directory containing the generated cert

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,7 +125,7 @@
   command: ./renew-certs.py
   args:
     chdir: "{{ acme_tiny_data_directory }}"
-  become_user: "{{ letsencrypt_user }}"
+  become_user: "{{ letsencrypt_default_key_owner }}"
   register: generate_initial_cert
   failed_when: "'error' in generate_initial_cert.stdout or 'Error' in generate_initial_cert.stdout or 'Error' in generate_initial_cert.stderr"
 
@@ -140,6 +140,6 @@
     minute: 30
     state: present
     name: "letsencrypt certificate renewal"
-    user: "{{ letsencrypt_user }}"
+    user: "{{ letsencrypt_default_key_owner }}"
 
 ...

--- a/templates/renew-certs.py
+++ b/templates/renew-certs.py
@@ -20,6 +20,10 @@ for cert in certs:
 
     host = ",".join(cert['host']) if type(cert['host']) is list else cert['host']
 
+    # Check that we can write the certificate file before generating it (to avoid burning Letencrypt quotas)
+    f = open(cert['certpath'], 'w')
+    f.close()
+
     print "Generating certificate for " + host
     args = [
         "/usr/bin/env", "python", script,


### PR DESCRIPTION
This is an attempt to fix ownership for the directory containing the generated cert.

See #5. I simply set the user running the script to be letsencrypt_default_key_owner (usually root). It works but it doesn't feel good to let the user run scripts as root. Do you have a better idea?
