### PR TITLE
Add option to generate chained cert with private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ give you the certificate!):
 
 The certificate will be placed in the path given in the `certpath` attribute.
 The `chainedcertpath` option gives you a certificate file consisting of the actual certificate and the intermediate
-certificate. This is e.g. useful for nginx. Note that you always need to also have the `certpath` option set, even
+certificate. This is e.g. useful for nginx. There is also a `fullchainedcertpath` option that works much the same, but
+will include the private key in the output. Note that you always need to also have the `certpath` option set, even
 if you only want to use the chained certificate.
 
 For multidomain certificates, all mentioned names must point to the server where the certificate is being generated.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -165,11 +165,19 @@
       or 'Error' in generate_initial_cert.stderr))
   tags: ['letsencrypt_keys']
 
-- name: generated chained certificates
+- name: generate chained certificate
   shell: cat {{ item.certpath }} {{ letsencrypt_intermediate_cert_path }} > {{ item.chainedcertpath }}
   args:
     creates: "{{ item.chainedcertpath }}"
   when: item.chainedcertpath is defined
+  with_items: letsencrypt_certs
+  tags: ['letsencrypt_keys']
+
+- name: generate full chained certificate
+  shell: cat {{ item.keypath }} {{ item.certpath }} {{ letsencrypt_intermediate_cert_path }} > {{ item.fullchainedcertpath }}
+  args:
+    creates: "{{ item.fullchainedcertpath }}"
+  when: item.fullchainedcertpath is defined
   with_items: letsencrypt_certs
   tags: ['letsencrypt_keys']
 


### PR DESCRIPTION
I'm using this role to generate a certificate for [ZNC](http://wiki.znc.in/ZNC). It's working great, except ZNC wants a .pem certificate file that includes the private key in addition to the certificate and intermediate chain. This adds another option to generate that file. Sort of a goofy proliferation of options, but that's life, I guess.
