### PR TITLE
Use Let's Encrypt Authority X3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,9 +23,9 @@ acme_tiny_challenges_directory: '/var/www/letsencrypt'
 
 letsencrypt_account_key: '{{ acme_tiny_data_directory }}/account.key'
 
-letsencrypt_intermediate_cert_path: '/etc/ssl/certs/lets-encrypt-x1-cross-signed.pem'
-letsencrypt_intermediate_cert_url: 'https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem'
-letsencrypt_intermediate_cert_sha256sum: '6c0a324bb803e9d66b8986ea2085bb9d6bdfe33f5c04a03a3f7024f4aa8e7a2d'
+letsencrypt_intermediate_cert_path: '/etc/ssl/certs/lets-encrypt-x3-cross-signed.pem'
+letsencrypt_intermediate_cert_url: 'https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem'
+letsencrypt_intermediate_cert_sha256sum: 'e446c5e9dbef9d09ac9f7027c034602492437a05ff6c40011d7235fca639c79a'
 
 letsencrypt_key_dir: '/etc/ssl/letsencrypt/keys'
 letsencrypt_certs_dir: '/etc/ssl/letsencrypt/certs'


### PR DESCRIPTION
Under normal circumstances, certificates issued by Let’s Encrypt will come from “Let’s Encrypt Authority X3”

https://letsencrypt.org/certificates/
