### PR TITLE
Generate chained certs in python script

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -155,7 +155,7 @@
   with_items: "{{ letsencrypt_certs }}"
   tags: ['letsencrypt_keys']
 
-- name: generate the initial certificate
+- name: generate the initial certificates
   command: ./renew-certs.py
   args:
     chdir: "{{ acme_tiny_data_directory }}"
@@ -164,22 +164,6 @@
   failed_when: (generate_initial_cert.stdout is defined and
     ('error' in generate_initial_cert.stdout or 'Error' in generate_initial_cert.stdout
       or 'Error' in generate_initial_cert.stderr))
-  tags: ['letsencrypt_keys']
-
-- name: generate chained certificate
-  shell: cat {{ item.certpath }} {{ letsencrypt_intermediate_cert_path }} > {{ item.chainedcertpath }}
-  args:
-    creates: "{{ item.chainedcertpath }}"
-  when: item.chainedcertpath is defined
-  with_items: "{{ letsencrypt_certs }}"
-  tags: ['letsencrypt_keys']
-
-- name: generate full chained certificate
-  shell: cat {{ item.keypath }} {{ item.certpath }} {{ letsencrypt_intermediate_cert_path }} > {{ item.fullchainedcertpath }}
-  args:
-    creates: "{{ item.fullchainedcertpath }}"
-  when: item.fullchainedcertpath is defined
-  with_items: "{{ letsencrypt_certs }}"
   tags: ['letsencrypt_keys']
 
 #################################################

--- a/templates/renew-certs.py
+++ b/templates/renew-certs.py
@@ -44,3 +44,17 @@ for cert in certs:
         f = open(cert['certpath'], 'w')
         f.write(output)
         f.close()
+        if 'chainedcertpath' in cert:
+          intermediate_cert = open('{{letsencrypt_intermediate_cert_path}}', 'r')
+          f = open(cert['chainedcertpath'], 'w')
+          f.write(output)
+          f.write(intermediate_cert.read())
+          f.close()
+        if 'fullchainedcertpath' in cert:
+          intermediate_cert = open('{{letsencrypt_intermediate_cert_path}}', 'r')
+          private_key = open(cert['keypath'], 'r')
+          f = open(cert['fullchainedcertpath'], 'w')
+          f.write(private_key.read())
+          f.write(output)
+          f.write(intermediate_cert.read())
+          f.close()


### PR DESCRIPTION
I realized that the best way to handle chained certs is to let the renewal script generate them. This ensures that chained certs will be regenerated whenever the main cert is.
