### PR TITLE
Bump acme tiny commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ certificates as soon as you have configured them.
 
 ## Requirements
 
-For every hostname you want to support, you need to have a webserver configured and add an alias that points to the 
+For every hostname you want to support, you need to have a webserver configured and add an alias that points to the
 directory configured with `acme_tiny_challenges_directory`. For Apache, such an alias should look like this:
 
     Alias "/.well-known/acme-challenge" "{{ acme_tiny_challenges_directory }}"
@@ -44,12 +44,13 @@ You might want to adjust these variables that control where the software and dat
 
   * `acme_tiny_software_directory`: The location to which acme-tiny is cloned
   * `acme_tiny_data_directory`: The location where the account key and certificate signature requests (CSR) are placed
-  * `acme_tiny_challenges_directory`: The (web-reachable) directory that contains the temporary challenges used for 
+  * `acme_tiny_challenges_directory`: The (web-reachable) directory that contains the temporary challenges used for
     verifying your domain ownership
   * `letsencrypt_intermediate_cert_path`: the path to which the intermediate certificate of Let’s encrypt will be
     downloaded.
   * `letsencrypt_account_key_source_file`: the path to the local account key file to copy over to the server. Leave this variable undefined to let this role generate the account key.
   * `letsencrypt_account_key_source_contents`: the actual content of the key file including the BEGIN and END headers. Leave this variable undefined to let this role generate the account key.
+  * `letsencrypt_post_renew_cmd`: Optional command to be run (as root) after a successful renewal.
 
 You can also adjust the user and group used for generating the certificates; there should be a dedicated user for this
 (recommended by the acme-tiny authors). The user and group are configured with these two variables:
@@ -62,7 +63,7 @@ the DNS A record points to, Let’s encrypt won’t be able to verify if the hos
 give you the certificate!):
 
     letsencrypt_certs:
-      - 
+      -
         name: "an_easily_recognizable_name__this_is_used_for_the_csr_file"
         keypath: "/path/to/your/keys/anything-you-like.key"
         certpath: "/path/to/your/certs/anything-you-like.crt"
@@ -112,7 +113,7 @@ does not support setting up a temporary server.
     - hosts: servers
       roles:
          - role: andreaswolf.letsencrypt
-      
+
       vars:
         letsencrypt_certs:
           -
@@ -126,7 +127,7 @@ does not support setting up a temporary server.
 This role is brand-new, so it needs testing. I tested it on Debian, where it works fine, but YMMV. If you can get it to
 run on other systems, I’d be happy to hear about that. I’m also happy if you report any issues you run into.
 
-During its public beta, _Let’s encrypt_ has a rate-limit of five certificates *per domain* per seven days 
+During its public beta, _Let’s encrypt_ has a rate-limit of five certificates *per domain* per seven days
 [source](https://community.letsencrypt.org/t/public-beta-rate-limits/4772). So two certificates for foo.example.org
 and bar.example.org use two of the seven available certs for example.org. This should be better handled by the role,
 by not regenerating certficates too often (probably you have multiple servers which host subdomains of the same domain,
@@ -145,7 +146,7 @@ MIT
 
 ## Author Information
 
-This role was created by Andreas Wolf. Visit my [website](http://a-w.io) and 
+This role was created by Andreas Wolf. Visit my [website](http://a-w.io) and
 [Github profile](https://github.com/andreaswolf/) or follow me on [Twitter](https://twitter.com/andreaswo).
 
 ### Contributors

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 acme_tiny_repo: 'https://github.com/diafygi/acme-tiny.git'
-acme_tiny_commit: '7a5a2558c8d6e5ab2a59b9fec9633d9e63127971'
+acme_tiny_commit: 'daba51d37efd7c1f205f9da383b9b09968e30d29'
 
 acme_tiny_software_directory: '/usr/local/letsencrypt'
 acme_tiny_data_directory: '/var/lib/letsencrypt'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,4 +55,8 @@ letsencrypt_min_renewal_age: 60
 # (60 days by default).
 letsencrypt_cronjob_daysofmonth: 1,11,21
 
+# Optional command to be run (as root) after a successful renewal.
+# Useful for triggering a webserver configuration reload for the new certificate.
+letsencrypt_post_renew_cmd: ''
+
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,8 +111,6 @@
     src: renew-certs.py
     dest: "{{ acme_tiny_data_directory }}/renew-certs.py"
     mode: 0700
-    owner: '{{ letsencrypt_user }}'
-    group: '{{ letsencrypt_group }}'
 
 - name: download intermediate certificate
   get_url: >
@@ -198,6 +196,5 @@
     minute: 30
     state: present
     name: "letsencrypt certificate renewal"
-    user: "{{ letsencrypt_user }}"
 
 ...

--- a/templates/renew-certs.py
+++ b/templates/renew-certs.py
@@ -1,46 +1,97 @@
 #!/usr/bin/env python
-
 import os
+import pwd
 import time
+from subprocess import Popen, PIPE
 
-from subprocess import Popen, PIPE, STDOUT
+def main():
+    """Main entry-point for certificate renewal"""
+    renewed = run_renew()
+    if renewed:
+        run_post_renew_cmd()
 
-certs = {{letsencrypt_certs}}
+def run_renew():
+    """Renews the certificate (run as the letsencrypt user)"""
+    certs = {{letsencrypt_certs}}
+    script = '{{ acme_tiny_software_directory }}/acme_tiny.py'
+    renewed = False
 
-script = "{{ acme_tiny_software_directory }}/acme_tiny.py"
+    user_name = '{{ letsencrypt_user }}'
+    pw_record = pwd.getpwnam(user_name)
+    user_name = pw_record.pw_name
+    user_uid = pw_record.pw_uid
+    user_gid = pw_record.pw_gid
+    env = os.environ.copy()
+    env['USER'] = user_name
 
-for cert in certs:
-    if os.access(cert['certpath'], os.F_OK):
-        stat = os.stat(cert['certpath'])
-        print "Certificate file " + cert['certpath'] + " already exists"
+    for cert in certs:
+        if os.access(cert['certpath'], os.F_OK):
+            stat = os.stat(cert['certpath'])
+            print 'Certificate file ' + cert['certpath'] + ' already exists'
 
-        if time.time() - stat.st_mtime < {{ letsencrypt_min_renewal_age }} * 86400:
-            print "  The certificate is younger than {{ letsencrypt_min_renewal_age }} days. Not creating a new certificate.\n"
-            continue
+            if time.time() - stat.st_mtime < {{ letsencrypt_min_renewal_age }} * 86400:
+                print ('  The certificate is younger than {{ letsencrypt_min_renewal_age }} days.' +
+                       ' Not creating a new certificate.\n')
+                continue
 
-    host = ",".join(cert['host']) if type(cert['host']) is list else cert['host']
+        host = ','.join(cert['host']) if type(cert['host']) is list else cert['host']
 
-    print "Generating certificate for " + host
-    args = [
-        "/usr/bin/env", "python", script,
+        print 'Generating certificate for ' + host
+        args = [
+            '/usr/bin/env', 'python', script,
+            '--account-key',
+            '{{ letsencrypt_account_key }}',
+            '--csr',
+            '{{ acme_tiny_data_directory }}/csrs/' + cert['name'] + '.csr',
+            '--acme-dir',
+            '{{ acme_tiny_challenges_directory }}'
+        ]
 
-        "--account-key",
-        "{{ letsencrypt_account_key }}",
-        "--csr",
-        "{{ acme_tiny_data_directory }}/csrs/" + cert['name'] + ".csr",
-        "--acme-dir",
-        "{{ acme_tiny_challenges_directory }}"
-    ]
+        cmd = ' '.join(args)
+        p = Popen(
+            cmd, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True,
+            preexec_fn=demote(user_uid, user_gid), env=env
+        )
+        output = p.stdout.read()
+        p.stdin.close()
+        if p.wait() != 0:
+            print 'error while generating certificate for {}'.format(host)
+            print p.stderr.read()
+        else:
+            f = open(cert['certpath'], 'w')
+            f.write(output)
+            f.close()
+            renewed = True
 
-    cmd = "/usr/bin/env " + " ".join(args)
+    return renewed
 
-    p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True)
-    output = p.stdout.read()
-    p.stdin.close()
-    if p.wait() != 0:
-        print "error while generating certificate for " + host
-        print p.stderr.read()
+
+def run_post_renew_cmd():
+    """Optionally runs a command after renewal (run as the root user)"""
+    post_renew_cmd = '{{ letsencrypt_post_renew_cmd }}'
+    if not len(post_renew_cmd):
+        print 'No post-renew command configured'
+        return
+
+    process = Popen(
+        post_renew_cmd, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True
+    )
+    output = process.stdout.read()
+    process.stdin.close()
+    if process.wait() != 0:
+        print 'Error while running post-renew command: {}'.format(post_renew_cmd)
+        print process.stderr.read()
     else:
-        f = open(cert['certpath'], 'w')
-        f.write(output)
-        f.close()
+        print 'Post-renew command completed successfully'
+
+
+def demote(user_uid, user_gid):
+    """Demotes to a non-root user before running a command"""
+    def result():
+        os.setgid(user_gid)
+        os.setuid(user_uid)
+    return result
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The new acme tiny commit updates the Let's Encrypt agreement URL,
since the old agreement URL is being rejected.
