### PR TITLE
move chained certificate creation to renew-certs.py

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -171,14 +171,6 @@
       or 'Error' in generate_initial_cert.stderr))
   tags: ['letsencrypt_keys']
 
-- name: generate chained certificate
-  shell: cat {{ item.certpath }} {{ letsencrypt_intermediate_cert_path }} > {{ item.chainedcertpath }}
-  args:
-    creates: "{{ item.chainedcertpath }}"
-  when: item.chainedcertpath is defined
-  with_items: "{{ letsencrypt_certs }}"
-  tags: ['letsencrypt_keys']
-
 - name: generate full chained certificate
   shell: cat {{ item.keypath }} {{ item.certpath }} {{ letsencrypt_intermediate_cert_path }} > {{ item.fullchainedcertpath }}
   args:

--- a/templates/renew-certs.py
+++ b/templates/renew-certs.py
@@ -7,6 +7,7 @@ from subprocess import Popen, PIPE, STDOUT
 
 certs = {{letsencrypt_certs}}
 
+intermediate_cert_path = "{{letsencrypt_intermediate_cert_path}}"
 script = "{{ acme_tiny_software_directory }}/acme_tiny.py"
 
 for cert in certs:
@@ -44,3 +45,8 @@ for cert in certs:
         f = open(cert['certpath'], 'w')
         f.write(output)
         f.close()
+        if 'chainedcertpath' in cert:
+            f = open(cert['chainedcertpath'], 'w')
+            i = open(intermediate_cert_path, 'r')
+            f.write(output + i.read())
+            f.close()


### PR DESCRIPTION
When renewing certificates I had the problem that my chained certificate wasn't updated as it only happens when running ansible. As my nginx is using the chained cert it should also be updated by the cronjob without running ansible. 

As a result and proposed change I moved the creation to the python script that is automatically run each renewal.