### PR TITLE
Refactored use of missing filter changed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,11 +93,11 @@
   command: >
     openssl rsa -in {{ letsencrypt_account_key }} -pubout
   register: account_public_key
-  when: generate_account_key | changed
+  when: generate_account_key.changed
 
 - name: "Please register the account public key with Letsencrypt, using for example https://gethttpsforfree.com/"
   debug: var=account_public_key.stdout
-  when: generate_account_key | changed
+  when: generate_account_key.changed
 
 
 - name: generate certificate renewal script


### PR DESCRIPTION
Hi,

thanks for this project. I noticed that for my version of ansible: `2.9.5` the changed filter does not exist. By removing it and using a dot syntax the problem is fixed.

I am using your version `v1.1` by the way.

Would you consider adding this to the main stream  please?

Best,
David