### PR TITLE
fix installation of python packages for modern Ubuntu

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,7 +81,19 @@
       - python-setuptools
       - python-pip
     state: present
-  when: ansible_os_family == 'Debian'
+  when: 
+    - ansible_os_family == 'Debian'
+    - ansible_distribution_version exists and ansible_distribution_version < '20.04'
+
+- name: install python-setuptools and pip (Debian)
+  apt:
+    pkg:
+      - python3-setuptools
+      - python3-pip
+    state: present
+  when: 
+    - ansible_os_family == 'Debian'
+    - ansible_distribution_version == '20.04'
 
 - name: install pip dependencies
   pip:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,7 +81,7 @@
       - python-setuptools
       - python-pip
     state: present
-  when: 
+  when:
     - ansible_os_family == 'Debian'
     - ansible_distribution_version exists and ansible_distribution_version < '20.04'
 
@@ -91,7 +91,7 @@
       - python3-setuptools
       - python3-pip
     state: present
-  when: 
+  when:
     - ansible_os_family == 'Debian'
     - ansible_distribution_version == '20.04'
 


### PR DESCRIPTION
Otherwise, on Ubuntu 20.04 LTS python-pip tries to install python 2.7. Which is bad ;) 